### PR TITLE
Uncomment useless import

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -2,11 +2,11 @@ from .model_setup import *
 
 # Generator
 # from .paste_gan import PasteGAN
-from .face_gan import FaceGAN
-from .face_gan_v2 import FaceGAN_v2
-from .face_gan_crn import FaceGAN_CRN
-from .face_gan_crn_v2 import FaceGAN_CRN_v2
-from .face_recon import Face_Recon
+# from .face_gan import FaceGAN
+# from .face_gan_v2 import FaceGAN_v2
+# from .face_gan_crn import FaceGAN_CRN
+# from .face_gan_crn_v2 import FaceGAN_CRN_v2
+# from .face_recon import Face_Recon
 from .encoder_decoder import EncoderDecoder
 
 # Lower level encoder decoders
@@ -14,8 +14,8 @@ from .voice_encoders import V2F1DCNN
 from .face_decoders import V2FDecoder
 
 # Progressive GAN
-from .pgan import PGan_Net
-from .pgan_dis import PGAN_Discriminator
+# from .pgan import PGan_Net
+# from .pgan_dis import PGAN_Discriminator
 
 # Discriminator
 from .discriminators import PatchDiscriminator

--- a/models/face_decoders.py
+++ b/models/face_decoders.py
@@ -22,10 +22,10 @@ try:
     from .networks import upBlock, GLU
 except:
     from networks import upBlock, GLU
-try:
-    from .pgan import PGan_Net
-except:
-    from pgan import PGan_Net
+# try:
+#     from .pgan import PGan_Net
+# except:
+#     from pgan import PGan_Net
 
 
 class DeConv2DBLK(nn.Module):
@@ -584,3 +584,4 @@ if __name__ == '__main__':
                           depthOtherScales=[512,512,512,256])
 
     img = pgandecoder(voice_embeddings)
+    

--- a/models/model_collection.py
+++ b/models/model_collection.py
@@ -12,10 +12,12 @@ except:
 
 try:
     from .face_decoders import V2FDecoder, AttnV2FDecoder, MRDecoder, \
-        FaceGanDecoder, FaceGanDecoder_v2, PganDecoder
+        FaceGanDecoder, FaceGanDecoder_v2
+        # PganDecoder
 except:
     from face_decoders import V2FDecoder, AttnV2FDecoder, MRDecoder, \
-        FaceGanDecoder, FaceGanDecoder_v2, PganDecoder
+        FaceGanDecoder, FaceGanDecoder_v2
+        # PganDecoder
 
 try:
     from .attention import Attention
@@ -32,7 +34,7 @@ class ModelCollection():
         self.MRDecoder = MRDecoder
         self.FaceGanDecoder = FaceGanDecoder
         self.FaceGanDecoder_v2 = FaceGanDecoder_v2
-        self.PganDecoder = PganDecoder
+        # self.PganDecoder = PganDecoder
         self.Attention = Attention
 
 

--- a/options/opts.py
+++ b/options/opts.py
@@ -84,9 +84,11 @@ options = {
 }
 
 with open(args.path_opts, "r") as f:
-    options_yaml = yaml.load(f)
+    # options_yaml = yaml.load(f)
+    options_yaml = yaml.full_load(f)
 with open(options_yaml["data"]["data_opts_path"], "r") as f:
-    data_opts = yaml.load(f)
+    # data_opts = yaml.load(f)
+    data_opts = yaml.full_load(f)
     options_yaml["data"]["data_opts"] = data_opts
 
 options = update_values(options, options_yaml)


### PR DESCRIPTION
There are two major changes:
- uncomment the useless model import in the files in `models`
- replacing `yaml.load` with `yaml.full_load` in `options/opts.py`